### PR TITLE
Fix party name formatting and center-align desktop column

### DIFF
--- a/src/components/hoc/GuestContent.tsx
+++ b/src/components/hoc/GuestContent.tsx
@@ -40,7 +40,7 @@ export const GuestContent = ({ party, user }: Props) => {
   return (
     <>
       <p>
-        Hey, {user.name}! Welcome to the {party.name}!<br />
+        Hey, {user.name}! Welcome to the {party.name.replace(/!+$/, '')}!<br />
       </p>
 
       {(participants.length > 1) && <p>Good news! {participants.join(' ')} are participating in this.</p>}

--- a/src/components/hoc/HostContent.tsx
+++ b/src/components/hoc/HostContent.tsx
@@ -22,7 +22,7 @@ const HostContent = ({ party, user }: Props) => {
 
   return (
     <>
-      <p>Hey, {user.name}! That's so awesome you're gathering the {party.name}!<br /></p>
+      <p>Hey, {user.name}! That's so awesome you're gathering the {party.name.replace(/!+$/, '')}!<br /></p>
       <p>{participantCount}</p>
       {party.participantCount! > 1 && <p>Here's a full list: {party.participants!.join(', ')}.</p>}
       <p>If you feel you're ready to Go then Go! Go ahead and press a button bellow. Have fun!</p>

--- a/src/components/hoc/PartyDetails.tsx
+++ b/src/components/hoc/PartyDetails.tsx
@@ -38,7 +38,7 @@ export const PartyDetails = ({ party }: Props) => {
                 )}
               </Content>
             </Columns.Column>
-            <Columns.Column desktop={{ size: 5 }}>
+            <Columns.Column desktop={{ size: 5 }} textAlign={"center"}>
               <GnomeSays>
                 <Content>
                   {party.target

--- a/src/components/hoc/PartyIsClosedContent.tsx
+++ b/src/components/hoc/PartyIsClosedContent.tsx
@@ -10,8 +10,8 @@ export const PartyIsClosedContent = ({ party, user }: Props) => {
   return (
     <>
       <p>
-        Hey, {user.name}! This is a new stage of the {party.name}! You are officially an Anonymous Ded Moroz!
-        Hooray! &#x1F389;
+        Hey, {user.name}! This is a new stage of the {party.name.replace(/!+$/, '')}!
+        You are officially an Anonymous Ded Moroz! Hooray! &#x1F389;
       </p>
       <p>
         {party.participantCount} awesome people are participating in this. Our very special elf finished his


### PR DESCRIPTION
This pull request fixes the party name formatting in the GuestContent and HostContent components by removing exclamation marks at the end of the party name. It also updates the PartyDetails component to center-align the desktop column.