### PR TITLE
Update dialog.scss styles for mobile view

### DIFF
--- a/src/styles/dialog.scss
+++ b/src/styles/dialog.scss
@@ -92,7 +92,7 @@
     background-size: 60%;
 
     @include mobile {
-      background-size: 90%;
+      background-size: 70%;
     }
   }
 
@@ -108,14 +108,15 @@
     margin: 2em 8em 2em 3em;
 
     @include mobile {
-      margin: 3em 0 6em;
+      margin: 0;
+
+      text-shadow: 1px 1px 2px white;
 
       ul {
         margin-right: 5em;
       }
 
       span {
-        background-color: rgba(#fff, 0.8);
         padding: 4px 8px;
         border-radius: 5px;
       }


### PR DESCRIPTION
This pull request updates the dialog.scss styles for mobile view. It adjusts the background-size to 70% instead of 90% and changes the margin to 0 for mobile devices. Additionally, it adds a text-shadow of 1px 1px 2px white to improve readability.