### PR TITLE
Add left alignment for mobile view in dialog.scss

### DIFF
--- a/src/styles/dialog.scss
+++ b/src/styles/dialog.scss
@@ -114,6 +114,7 @@
     @include mobile {
       margin: 0;
 
+      text-align: left;
       text-shadow: 1px 1px 2px white;
     }
   }


### PR DESCRIPTION
This pull request adds left alignment for the mobile view in the dialog.scss file. This change ensures that the text in the dialog is aligned to the left when viewed on mobile devices.