### PR TITLE
Fix JoinBox setBusy bug

### DIFF
--- a/src/components/hoc/JoinBox.tsx
+++ b/src/components/hoc/JoinBox.tsx
@@ -24,8 +24,8 @@ export const JoinBox = ({ party }: Props) => {
 
   const onActionClick = React.useCallback(
     () => {
-      setBusy(true);
       if (!user) {
+        setBusy(true);
         setTimeout(() => {
           signIn({
             id: "123",


### PR DESCRIPTION
This pull request fixes a bug in the JoinBox component where the setBusy function was called in the wrong order. The setBusy function is now called after checking if the user is authenticated. This ensures that the busy state is correctly set when the user is not authenticated.