### PR TITLE
Add border to grinch-box and align text in login form

### DIFF
--- a/src/styles/grinch-box.scss
+++ b/src/styles/grinch-box.scss
@@ -8,6 +8,7 @@
     position: relative;
     transition: all 0.25s ease-in-out;
     max-width: 600px;
+    border: 1px solid rgba(#fff, 0.2);
 
     img {
       position: absolute;

--- a/src/styles/login.scss
+++ b/src/styles/login.scss
@@ -46,6 +46,10 @@
         padding: 0;
         font-size: 1rem;
       }
+
+      p {
+        text-align: left;
+      }
     }
 
     .help {


### PR DESCRIPTION
This pull request adds a border to the grinch-box element and aligns the text in the login form. The border is set to 1px solid rgba(#fff, 0.2) and the text is aligned to the left. These changes improve the visual appearance and readability of the login form.