### PR TITLE
Comment out navigate("/") in EnterContainer.tsx

### DIFF
--- a/src/components/hoc/EnterContainer.tsx
+++ b/src/components/hoc/EnterContainer.tsx
@@ -80,7 +80,7 @@ export const EnterContainer = () => {
 
           signIn({ profile: user, userToken });
 
-          navigate("/");
+          // navigate("/");
         }
         catch (e) {
           const { code } = e as JOSEError;


### PR DESCRIPTION
This pull request comments out the navigate("/") line in the EnterContainer.tsx file to prevent the user from being redirected to the home page after signing in.