### PR TITLE
Refactor JoinBox component to use the useCurrentUser hook

### DIFF
--- a/src/components/hoc/JoinBox.tsx
+++ b/src/components/hoc/JoinBox.tsx
@@ -43,9 +43,7 @@ const signInValidationSchema = Yup.object().shape({
 export const JoinBox = ({ party }: Props) => {
   const navigate = useNavigate();
 
-  // const { profile } = useCurrentUser();
-  const profile = null;
-
+  const { profile } = useCurrentUser();
 
   const onGoHomeClick = React.useCallback(() => navigate('/'), [navigate]);
 


### PR DESCRIPTION
This pull request refactors the JoinBox component to use the useCurrentUser hook instead of directly accessing the profile. This improves code readability and maintainability.