### PR TITLE
Update JoinBox component to use party code instead of party id

### DIFF
--- a/src/components/hoc/JoinBox.tsx
+++ b/src/components/hoc/JoinBox.tsx
@@ -160,7 +160,7 @@ const SignInControls = ({ party }: SignInControlsProps) => {
   if (displayForm) {
     return (
       <Form
-        initialValues={{ email: "", party: party.id }}
+        initialValues={{ email: "", party: party.code }}
         validationSchema={signInValidationSchema}
         onSubmit={onSubmit}
       >


### PR DESCRIPTION
This pull request updates the JoinBox component to use the party code instead of the party id. This change ensures that the correct party code is used for the initial values in the SignInControls form.